### PR TITLE
修复寄存器过多时，可能出现的数组越界

### DIFF
--- a/examples/slave/bits.c
+++ b/examples/slave/bits.c
@@ -2,26 +2,26 @@
 
 static uint8_t _tab_bits[10] = {0, 1, 0, 1, 0, 1, 0, 1, 0, 1};
 
-static int get_map_buf(void *buf, int bufsz)
+static int get_map_buf(int index, void *buf, int bufcnt)
 {
     uint8_t *ptr = (uint8_t *)buf;
 
     pthread_mutex_lock(&slave_mtx);
-    for (int i = 0; i < sizeof(_tab_bits); i++) {
-        ptr[i] = _tab_bits[i];
+    for (int i = 0; i < bufcnt && i + index < sizeof(_tab_bits); i++) {
+        ptr[i] = _tab_bits[index + i];
     }
     pthread_mutex_unlock(&slave_mtx);
 
     return 0;
 }
 
-static int set_map_buf(int index, int len, void *buf, int bufsz)
+static int set_map_buf(int index, void *buf, int bufcnt)
 {
     uint8_t *ptr = (uint8_t *)buf;
 
     pthread_mutex_lock(&slave_mtx);
-    for (int i = 0; i < len; i++) {
-        _tab_bits[index + i] = ptr[index + i];
+    for (int i = 0; i < bufcnt && i + index < sizeof(_tab_bits); i++) {
+        _tab_bits[index + i] = ptr[i];
     }
     pthread_mutex_unlock(&slave_mtx);
 

--- a/examples/slave/input_bits.c
+++ b/examples/slave/input_bits.c
@@ -2,13 +2,13 @@
 
 static uint8_t _tab_input_bits[10] = {0, 1, 1, 0, 0, 1, 1, 0, 0, 1};
 
-static int get_map_buf(void *buf, int bufsz)
+static int get_map_buf(int index, void *buf, int bufcnt)
 {
     uint8_t *ptr = (uint8_t *)buf;
 
     pthread_mutex_lock(&slave_mtx);
-    for (int i = 0; i < sizeof(_tab_input_bits); i++) {
-        ptr[i] = _tab_input_bits[i];
+    for (int i = 0; i < bufcnt && i + index < sizeof(_tab_input_bits); i++) {
+        ptr[i] = _tab_input_bits[index + i];
     }
     pthread_mutex_unlock(&slave_mtx);
 

--- a/examples/slave/input_registers.c
+++ b/examples/slave/input_registers.c
@@ -2,13 +2,13 @@
 
 static uint16_t _tab_input_registers[10] = {0, 1, 2, 3, 4, 9, 8, 7, 6, 5};
 
-static int get_map_buf(void *buf, int bufsz)
+static int get_map_buf(int index, void *buf, int bufcnt)
 {
     uint16_t *ptr = (uint16_t *)buf;
 
     pthread_mutex_lock(&slave_mtx);
-    for (int i = 0; i < sizeof(_tab_input_registers) / sizeof(_tab_input_registers[0]); i++) {
-        ptr[i] = _tab_input_registers[i];
+    for (int i = 0; i < bufcnt && i + index < sizeof(_tab_input_registers) / sizeof(_tab_input_registers[0]); i++) {
+        ptr[i] = _tab_input_registers[index + i];
     }
     pthread_mutex_unlock(&slave_mtx);
 

--- a/examples/slave/registers.c
+++ b/examples/slave/registers.c
@@ -2,26 +2,26 @@
 
 static uint16_t _tab_registers[10] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
-static int get_map_buf(void *buf, int bufsz)
+static int get_map_buf(int index, void *buf, int bufcnt)
 {
     uint16_t *ptr = (uint16_t *)buf;
 
     pthread_mutex_lock(&slave_mtx);
-    for (int i = 0; i < sizeof(_tab_registers) / sizeof(_tab_registers[0]); i++) {
-        ptr[i] = _tab_registers[i];
+    for (int i = 0; i < bufcnt && i + index < sizeof(_tab_registers) / sizeof(_tab_registers[0]); i++) {
+        ptr[i] = _tab_registers[index + i];
     }
     pthread_mutex_unlock(&slave_mtx);
 
     return 0;
 }
 
-static int set_map_buf(int index, int len, void *buf, int bufsz)
+static int set_map_buf(int index, void *buf, int bufcnt)
 {
     uint16_t *ptr = (uint16_t *)buf;
 
     pthread_mutex_lock(&slave_mtx);
-    for (int i = 0; i < len; i++) {
-        _tab_registers[index + i] = ptr[index + i];
+    for (int i = 0; i < bufcnt && i + index < sizeof(_tab_registers) / sizeof(_tab_registers[0]); i++) {
+        _tab_registers[index + i] = ptr[i];
     }
     pthread_mutex_unlock(&slave_mtx);
 

--- a/util/agile_modbus_slave_util.h
+++ b/util/agile_modbus_slave_util.h
@@ -38,8 +38,8 @@ extern "C" {
 typedef struct agile_modbus_slave_util_map {
     int start_addr;                                       /**<Start address */
     int end_addr;                                         /**< end address */
-    int (*get)(void *buf, int bufsz);                     /**< Get register data interface */
-    int (*set)(int index, int len, void *buf, int bufsz); /**< Set register data interface */
+    int (*get)(int index, void *buf, int bufcnt);         /**< Get register data interface */
+    int (*set)(int index, void *buf, int bufcnt);         /**< Set register data interface */
 } agile_modbus_slave_util_map_t;
 
 /**


### PR DESCRIPTION
## 问题
当用户定义的寄存器过多时，存在数组越界情况。如下图：
![异常说明](https://github.com/user-attachments/assets/a5332498-224e-45cd-a8ac-848470cb2f85)


## 解决方式
详见PR详情

## 测试
使用modbus poll工具进行测试，初步测试项目包括（0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x0F, 0x10, 0x16, 0x17,）。未发现异常。
![测试截图](https://github.com/user-attachments/assets/4a6dfd20-2dfe-40b1-8a94-230acfd55ce7)


## 注意
1：本次PR仅关注modbus RTU，未关注TCP
2：本次pr，修改了get_map_buf等回调函数的传参，因为该函数由用户实现，故更新后**需要用户简单修改get_map_buf等回调函数**（参照\examples\slave）
