### PR TITLE
Add threading library linkage to TCP master

### DIFF
--- a/examples/tcp_master/CMakeLists.txt
+++ b/examples/tcp_master/CMakeLists.txt
@@ -5,3 +5,5 @@ project(tcp_master)
 file(GLOB SRCS *.c)
 
 add_executable(TcpMaster ${SRCS})
+
+target_link_libraries(TcpMaster PRIVATE Threads::Threads)


### PR DESCRIPTION
Links the TCP master executable against the system threading library
to enable multi-threaded capabilities for network communications